### PR TITLE
Updated PhpMetrics to v2.3.2

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -317,7 +317,7 @@
       "website": "http://www.phpmetrics.org/",
       "command": {
         "phar-download": {
-          "phar": "https://github.com/phpmetrics/PhpMetrics/releases/download/v2.3.0/phpmetrics.phar",
+          "phar": "https://github.com/phpmetrics/PhpMetrics/releases/download/v2.3.2/phpmetrics.phar",
           "bin": "/usr/local/bin/phpmetrics"
         }
       },


### PR DESCRIPTION
Small bit of maintenance. I've gone through the packages that use Github releases and checked they are up to date with the latest release. PhpMetrics was the only tool that needed updating.

| Tool | Old Version | New Version |
| - | - | - |
| PhpMetrics | v2.3.0 | v2.3.2 |
