### PR TITLE
Add EasyCodingStandard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c unzip"
 ENV LIB_DEPS="zlib1g-dev"
 ENV TOOL_DEPS="git graphviz"
-ENV PATH="$PATH:/root/.composer/vendor/bin:/root/QualityAnalyzer/bin:/root/DesignPatternDetector/bin"
+ENV PATH="$PATH:/root/.composer/vendor/bin:/root/QualityAnalyzer/bin:/root/DesignPatternDetector/bin:/root/EasyCodingStandard/bin"
 ENV TOOLS_JSON=/root/tools.json
 
 ADD tools.json ${TOOLS_JSON}

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -6,7 +6,7 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkgconf re2c unzip"
 ENV LIB_DEPS="zlib-dev"
 ENV TOOL_DEPS="git graphviz"
-ENV PATH="$PATH:/root/.composer/vendor/bin:/root/QualityAnalyzer/bin:/root/DesignPatternDetector/bin"
+ENV PATH="$PATH:/root/.composer/vendor/bin:/root/QualityAnalyzer/bin:/root/DesignPatternDetector/bin:/root/EasyCodingStandard/bin"
 ENV TOOLS_JSON=/root/tools.json
 
 ADD tools.json ${TOOLS_JSON}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Docker image providing static analysis tools for PHP.
 * deprecation-detector - [Finds usages of deprecated code](https://github.com/sensiolabs-de/deprecation-detector)
 * deptrac - [Enforces dependency rules](https://github.com/sensiolabs-de/deptrac)
 * design-pattern - [Detects design patterns](https://github.com/Halleck45/DesignPatternDetector)
+* EasyCodingStandard - [Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer](https://github.com/Symplify/EasyCodingStandard)
 * parallel-lint - [Checks PHP file syntax](https://github.com/JakubOnderka/PHP-Parallel-Lint)
 * pdepend - [Static Analysis Tool](https://pdepend.org/)
 * phan - [Static Analysis Tool](https://github.com/etsy/phan)

--- a/tools.json
+++ b/tools.json
@@ -70,6 +70,17 @@
       "test": "design-pattern -V"
     },
     {
+      "name": "EasyCodingStandard",
+      "summary": "Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer",
+      "website": "https://github.com/Symplify/EasyCodingStandard",
+      "command": {
+        "composer-global-install": {
+          "package": "symplify/easy-coding-standard"
+        }
+      },
+      "test": "ecs -h"
+    },
+    {
       "name": "parallel-lint",
       "summary": "Checks PHP file syntax",
       "website": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
@@ -122,9 +133,8 @@
       "summary": "PHP Coding Standards Fixer",
       "website": "http://cs.sensiolabs.org/",
       "command": {
-        "phar-download": {
-          "phar": "http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar",
-          "bin": "/usr/local/bin/php-cs-fixer"
+        "composer-global-install": {
+          "package": "friendsofphp/php-cs-fixer"
         }
       },
       "test": "php-cs-fixer list"
@@ -252,9 +262,8 @@
       "summary": "Detects coding standard violations",
       "website": "https://github.com/squizlabs/PHP_CodeSniffer",
       "command": {
-        "phar-download": {
-          "phar": "https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar",
-          "bin": "/usr/local/bin/phpcs"
+        "composer-global-install": {
+          "package": "squizlabs/php_codesniffer"
         }
       },
       "test": "phpcs --help"

--- a/tools.json
+++ b/tools.json
@@ -74,8 +74,8 @@
       "summary": "Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer",
       "website": "https://github.com/Symplify/EasyCodingStandard",
       "command": {
-        "composer-global-install": {
-          "package": "symplify/easy-coding-standard"
+        "composer-install": {
+          "repository": "https://github.com/Symplify/EasyCodingStandard.git"
         }
       },
       "test": "ecs -h"
@@ -133,8 +133,9 @@
       "summary": "PHP Coding Standards Fixer",
       "website": "http://cs.sensiolabs.org/",
       "command": {
-        "composer-global-install": {
-          "package": "friendsofphp/php-cs-fixer"
+        "phar-download": {
+          "phar": "http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar",
+          "bin": "/usr/local/bin/php-cs-fixer"
         }
       },
       "test": "php-cs-fixer list"
@@ -262,8 +263,9 @@
       "summary": "Detects coding standard violations",
       "website": "https://github.com/squizlabs/PHP_CodeSniffer",
       "command": {
-        "composer-global-install": {
-          "package": "squizlabs/php_codesniffer"
+        "phar-download": {
+          "phar": "https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar",
+          "bin": "/usr/local/bin/phpcs"
         }
       },
       "test": "phpcs --help"


### PR DESCRIPTION
I have changed phar based installation to composer ones because these are dependencies of ecs, so they would be needlessly installed twice. Will change it back if you want.