### PR TITLE
Dockerfile maintenance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.1-cli
 
-MAINTAINER Jakub Zalas <jakub@zalas.pl>
+LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c unzip"
@@ -9,8 +9,8 @@ ENV TOOL_DEPS="git graphviz"
 ENV PATH="$PATH:/root/.composer/vendor/bin:/root/QualityAnalyzer/bin:/root/DesignPatternDetector/bin:/root/EasyCodingStandard/bin"
 ENV TOOLS_JSON=/root/tools.json
 
-ADD tools.json ${TOOLS_JSON}
-ADD tools.php /usr/local/bin/tools.php
+COPY tools.json ${TOOLS_JSON}
+COPY tools.php /usr/local/bin/tools.php
 
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,6 +1,6 @@
 FROM php:7.1-alpine
 
-MAINTAINER Jakub Zalas <jakub@zalas.pl>
+LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkgconf re2c unzip"
@@ -9,8 +9,8 @@ ENV TOOL_DEPS="git graphviz"
 ENV PATH="$PATH:/root/.composer/vendor/bin:/root/QualityAnalyzer/bin:/root/DesignPatternDetector/bin:/root/EasyCodingStandard/bin"
 ENV TOOLS_JSON=/root/tools.json
 
-ADD tools.json ${TOOLS_JSON}
-ADD tools.php /usr/local/bin/tools.php
+COPY tools.json ${TOOLS_JSON}
+COPY tools.php /usr/local/bin/tools.php
 
 RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \


### PR DESCRIPTION
This removes the deprecated `MAINTAINER` instruction from the Dockerfile (see [here](https://docs.docker.com/engine/deprecated/#maintainer-in-dockerfile)) and uses `COPY` in favour of `ADD` as per [best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy) for writing Dockerfiles.
