### PR TITLE
Install tagged versions with box and composer install (if available)

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -177,7 +177,8 @@
         "box-build": {
           "repository": "https://github.com/mmoreram/php-formatter.git",
           "phar": "build/php-formatter.phar",
-          "bin": "/usr/local/bin/php-formatter"
+          "bin": "/usr/local/bin/php-formatter",
+          "version": "1fa3d9a3e1c67654f3fe2511bd28fa7c33b59d7e"
         }
       },
       "test": "php-formatter list"

--- a/tools.php
+++ b/tools.php
@@ -169,7 +169,7 @@ namespace Model {
         public function __toString(): string
         {
             return sprintf(
-                'cd $HOME && git clone %s && cd $HOME/%s && composer install --no-dev --no-suggest --prefer-dist -n && box build && mv %s %s && chmod +x %s && cd && rm -rf $HOME/%s',
+                'cd $HOME && git clone %s && cd $HOME/%s && git checkout $(git describe --tags $(git rev-list --tags --max-count=1)) && composer install --no-dev --no-suggest --prefer-dist -n && box build && mv %s %s && chmod +x %s && cd && rm -rf $HOME/%s',
                 $this->repository,
                 $this->getTargetDir(),
                 $this->phar,
@@ -204,7 +204,7 @@ namespace Model {
         public function __toString(): string
         {
             return sprintf(
-                'cd $HOME && git clone %s && cd $HOME/%s && composer install --no-dev --no-suggest --prefer-dist -n',
+                'cd $HOME && git clone %s && cd $HOME/%s && git checkout $(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null) && composer install --no-dev --no-suggest --prefer-dist -n',
                 $this->repository,
                 $this->getTargetDir()
             );

--- a/tools.php
+++ b/tools.php
@@ -151,27 +151,30 @@ namespace Model {
         private $repository;
         private $phar;
         private $bin;
+        private $version;
 
-        private function __construct(string $repository, string $phar, string $bin)
+        private function __construct(string $repository, string $phar, string $bin, ?string $version = null)
         {
             $this->repository = $repository;
             $this->phar = $phar;
             $this->bin = $bin;
+            $this->version = $version;
         }
 
         public static function import(array $command): Command
         {
             \Assert\requireFields(['repository', 'phar', 'bin'], $command, 'BoxBuildCommand');
 
-            return new self($command['repository'], $command['phar'], $command['bin']);
+            return new self($command['repository'], $command['phar'], $command['bin'], $command['version'] ?? null);
         }
 
         public function __toString(): string
         {
             return sprintf(
-                'cd $HOME && git clone %s && cd $HOME/%s && git checkout $(git describe --tags $(git rev-list --tags --max-count=1)) && composer install --no-dev --no-suggest --prefer-dist -n && box build && mv %s %s && chmod +x %s && cd && rm -rf $HOME/%s',
+                'cd $HOME && git clone %s && cd $HOME/%s && git checkout %s && composer install --no-dev --no-suggest --prefer-dist -n && box build && mv %s %s && chmod +x %s && cd && rm -rf $HOME/%s',
                 $this->repository,
                 $this->getTargetDir(),
+                $this->version ?? '$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null)',
                 $this->phar,
                 $this->bin,
                 $this->bin,
@@ -188,25 +191,28 @@ namespace Model {
     final class ComposerInstallCommand implements Command
     {
         private $repository;
+        private $version;
 
-        public function __construct(string $repository)
+        public function __construct(string $repository, ?string $version = null)
         {
             $this->repository = $repository;
+            $this->version = $version;
         }
 
         public static function import(array $command): Command
         {
             \Assert\requireFields(['repository'], $command, 'ComposerInstallCommand');
 
-            return new self($command['repository']);
+            return new self($command['repository'], $command['version'] ?? null);
         }
 
         public function __toString(): string
         {
             return sprintf(
-                'cd $HOME && git clone %s && cd $HOME/%s && git checkout $(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null) && composer install --no-dev --no-suggest --prefer-dist -n',
+                'cd $HOME && git clone %s && cd $HOME/%s && git checkout %s && composer install --no-dev --no-suggest --prefer-dist -n',
                 $this->repository,
-                $this->getTargetDir()
+                $this->getTargetDir(),
+                $this->version ?? '$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null)'
             );
         }
 


### PR DESCRIPTION
The latest tag will now be used with box and composer installations if it's available.

Since not all tagged version actually build cleanly (i.e. php-formatter), I also added a way to force the version to install in both installation methods:

```json
"box-build": {
    "repository": "https://github.com/mmoreram/php-formatter.git",
    "phar": "build/php-formatter.phar",
    "bin": "/usr/local/bin/php-formatter",
    "version": "1fa3d9a3e1c67654f3fe2511bd28fa7c33b59d7e"
},
"composer-install": {
    "repository": "https://github.com/Symplify/EasyCodingStandard.git",
    "version": "v2.5.12"
}

```