### PR TITLE
Use composer-bin-plugin with phpstan and other packages installed globally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,158 @@ Please note we have a [code of conduct](CODE_OF_CONDUCT.md). Please follow it in
 
 ## Pull Request Process
 
-* Prefer `phar` downloads over `composer global` installations to avoid dependency conflicts.
-* Update the `README.md` and `tools.json` with any new tools'd like to add.
+* Prefer `phar` downloads or `composer-bin-plugin` installation over `composer global` installations to avoid dependency conflicts.
+* Update the `README.md` and `tools.json` with any new tools'd like to add (`php tools.php update-readme`).
 * Ensure any install or build dependencies are removed before the end of the layer when doing a build.
 * Make changes to both Debian and Alpine images (`Dockerfile` and `Dockerfile-alpine`).
 * Provide a good commit message describing what you've done.
+
+## Adding a new tool
+
+To add support for a new tool, add it to the list in `tools.json`:
+
+```json
+{
+  "name": "behat",
+  "summary": "Helps to test business expectations",
+  "website": "http://behat.org/",
+  "command": {
+    "composer-bin-plugin": {
+      "package": "behat/behat",
+      "namespace": "behat"
+    }
+  },
+  "test": "behat --version"
+}
+```
+
+Each tool should have the following properties specified:
+
+* `name` - name of the tool, most of the time the name of executable;
+* `summary` - shortly stated purpose of the tool;
+* `website` - link to the tool's website;
+* `command` - the command to install the tool. See supported commands below;
+* `test` - the command to verify if the tool is installed. Most of the time it will be the command to show the version or help;
+
+Once you added a new tool to the list, update the list in `README.md` by running the following command:
+
+```bash
+php tools.php update-readme
+```
+
+### Commands
+
+There are several supported ways to install tools in the phpqa image.
+All of them are listed below in order of preference.
+
+#### composer-bin-plugin
+
+The `composer-bin-plugin` method Uses [bamarni/composer-bin-plugin](https://github.com/bamarni/composer-bin-plugin)
+to install the package in isolated directory.
+Thanks to the isolation we're less likely to run into problem with conflicting dependencies between tools.
+
+```json
+{
+  "command": {
+    "composer-bin-plugin": {
+      "package": "behat/behat",
+      "namespace": "behat"
+    }
+  }
+}
+```
+
+#### phar-download
+
+Downloads a phar from the given URL and puts it into the specified location.
+
+```json
+{
+  "command": {
+    "phar-download": {
+      "phar": "https://github.com/phpspec/phpspec/releases/download/4.3.0/phpspec.phar",
+      "bin": "/usr/local/bin/phpspec"
+    }
+  }
+}
+```
+
+#### file-download
+
+Downloads a file from the given URL and puts it into the specified location.
+
+```json
+{
+  "command": {
+    "file-download": {
+      "url": "https://github.com/vimeo/psalm/releases/download/2.0.0/psalm.phar.asc",
+      "file": "/usr/local/bin/psalm.phar.asc"
+    }
+  }
+}
+```
+
+#### box-build
+
+Uses [box](https://box-project.github.io/box2/) to build a phar and puts it into the specified location.
+It will clone the given repository and checkout the latest tag if available.
+
+```json
+{
+  "command": {
+    "box-build": {
+      "repository": "https://github.com/behat/behat.git",
+      "phar": "behat.phar",
+      "bin": "/usr/local/bin/behat"
+    }
+  }
+}
+```
+
+#### composer-global-install
+
+Uses the `composer global require` command to install a composer package globally.
+
+```json
+{
+  "command": {
+    "composer-global-install": {
+      "package": "bmitch/churn-php"
+    }
+  }
+}
+```
+
+#### composer-install
+
+Clones the specified repository, checkouts the latest tag (if available), and runs `composer install` inside.
+Mostly useful for applications.
+
+```json
+{
+  "command": {
+    "composer-install": {
+      "repository": "https://github.com/Qafoo/QualityAnalyzer.git"
+    }
+  }
+}
+```
+
+#### Executing multiple commands
+
+It's sometimes useful to run multiple installation commands i.e. when downloading a phar and its signature.
+
+```json
+{
+  "command": {
+    "file-download": {
+      "url": "https://github.com/vimeo/psalm/releases/download/2.0.0/psalm.phar.asc",
+      "file": "/usr/local/bin/psalm.phar.asc"
+    },
+    "phar-download": {
+      "phar": "https://github.com/vimeo/psalm/releases/download/2.0.0/psalm.phar",
+      "bin": "/usr/local/bin/psalm"
+    }
+  }
+}
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c unzip"
-ENV LIB_DEPS="libbz2-dev zlib1g-dev"
+ENV LIB_DEPS="zlib1g-dev"
 ENV TOOL_DEPS="git graphviz"
 ENV PATH="$PATH:/root/.composer/vendor/bin:/root/QualityAnalyzer/bin:/root/DesignPatternDetector/bin:/root/EasyCodingStandard/bin"
 ENV TOOLS_JSON=/root/tools.json
@@ -15,7 +15,7 @@ COPY --from=composer:1.6 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
- && docker-php-ext-install bz2 zip \
+ && docker-php-ext-install zip \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -4,7 +4,7 @@ LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkgconf re2c unzip"
-ENV LIB_DEPS="bzip2-dev zlib-dev"
+ENV LIB_DEPS="zlib-dev"
 ENV TOOL_DEPS="git graphviz"
 ENV PATH="$PATH:/root/.composer/vendor/bin:/root/QualityAnalyzer/bin:/root/DesignPatternDetector/bin:/root/EasyCodingStandard/bin"
 ENV TOOLS_JSON=/root/tools.json
@@ -16,7 +16,7 @@ COPY --from=composer:1.6 /usr/bin/composer /usr/bin/composer
 RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
- && docker-php-ext-install bz2 zip \
+ && docker-php-ext-install zip \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Nightly builds: https://hub.docker.com/r/jakzal/phpqa-nightly/
 ## Available tools
 
 * composer - [Dependency Manager for PHP](https://getcomposer.org/)
+* composer-bin-plugin - [Composer plugin to install bin vendors in isolated locations](https://github.com/bamarni/composer-bin-plugin)
 * box - [An application for building and managing Phars](https://box-project.github.io/box2/)
 * analyze - [Visualizes metrics and source code](https://github.com/Qafoo/QualityAnalyzer)
 * behat - [Helps to test business expectations](http://behat.org/)

--- a/tools.json
+++ b/tools.json
@@ -405,12 +405,12 @@
       "summary": "Static Analysis Tool",
       "website": "https://github.com/phpstan/phpstan",
       "command": {
-        "phar-download": {
-          "phar": "https://github.com/phpstan/phpstan/releases/download/0.9.2/phpstan.phar",
-          "bin": "/usr/local/bin/phpstan"
+        "composer-bin-plugin": {
+          "package": "phpstan/phpstan",
+          "namespace": "phpstan"
         }
       },
-      "test": "phpstan list"
+      "test": "phpstan --version"
     },
     {
       "name": "phpunit",

--- a/tools.json
+++ b/tools.json
@@ -29,8 +29,9 @@
       "summary": "Discovers good candidates for refactoring",
       "website": "https://github.com/bmitch/churn-php",
       "command": {
-        "composer-global-install": {
-          "package": "bmitch/churn-php"
+        "composer-bin-plugin": {
+          "package": "bmitch/churn-php",
+          "namespace": "tools"
         }
       },
       "test": "churn list"
@@ -151,8 +152,9 @@
       "summary": "Detects code coupling issues",
       "website": "https://akeneo.github.io/php-coupling-detector/",
       "command": {
-        "composer-global-install": {
-          "package": "akeneo/php-coupling-detector"
+        "composer-bin-plugin": {
+          "package": "akeneo/php-coupling-detector",
+          "namespace": "tools"
         }
       },
       "test": "php-coupling-detector list"
@@ -212,8 +214,9 @@
       "summary": "Checks for weak assumptions",
       "website": "https://github.com/rskuipers/php-assumptions",
       "command": {
-        "composer-global-install": {
-          "package": "rskuipers/php-assumptions:dev-master"
+        "composer-bin-plugin": {
+          "package": "rskuipers/php-assumptions:dev-master",
+          "namespace": "tools"
         }
       },
       "test": "phpa"
@@ -335,8 +338,9 @@
       "summary": "A tool that can speed up linting of php files by running several lint processes at once",
       "website": "https://github.com/overtrue/phplint",
       "command": {
-        "composer-global-install": {
-          "package": "overtrue/phplint"
+        "composer-bin-plugin": {
+          "package": "overtrue/phplint",
+          "namespace": "tools"
         }
       },
       "test": "phplint -V"
@@ -382,8 +386,9 @@
       "summary": "Helps to detect magic numbers",
       "website": "https://github.com/povils/phpmnd",
       "command": {
-        "composer-global-install": {
-          "package": "povils/phpmnd"
+        "composer-bin-plugin": {
+          "package": "povils/phpmnd",
+          "namespace": "tools"
         }
       },
       "test": "phpmnd -V"
@@ -457,8 +462,9 @@
       "summary": "Analyses and reports testability issues of a php codebase",
       "website": "https://github.com/edsonmedina/php_testability",
       "command": {
-        "composer-global-install": {
-          "package": "edsonmedina/php_testability:dev-master"
+        "composer-bin-plugin": {
+          "package": "edsonmedina/php_testability:dev-master",
+          "namespace": "tools"
         }
       },
       "test": "testability --help"

--- a/tools.json
+++ b/tools.json
@@ -367,7 +367,7 @@
           "bin": "/usr/local/bin/phpmd"
         }
       },
-      "test": "phpmd /usr/local/bin/tools.php text unusedcode"
+      "test": "phpmd --version"
     },
     {
       "name": "phpmetrics",

--- a/tools.json
+++ b/tools.json
@@ -226,9 +226,9 @@
       "summary": "Finds usage of non-built-in extensions",
       "website": "https://github.com/wapmorgan/PhpCodeAnalyzer",
       "command": {
-        "phar-download": {
-          "phar": "https://github.com/wapmorgan/PhpCodeAnalyzer/releases/download/1.0.4/phpca.phar",
-          "bin": "/usr/local/bin/phpca"
+        "composer-bin-plugin": {
+          "package": "wapmorgan/php-code-analyzer",
+          "namespace": "tools"
         }
       },
       "test": "phpca -h"
@@ -262,9 +262,9 @@
       "summary": "Finds usage of deprecated features",
       "website": "http://wapmorgan.github.io/PhpCodeFixer/",
       "command": {
-        "phar-download": {
-          "phar": "https://github.com/wapmorgan/PhpCodeFixer/releases/download/2.0.13/phpcf-2.0.13-1-g0dd0ff3.phar",
-          "bin": "/usr/local/bin/phpcf"
+        "composer-bin-plugin": {
+          "package": "wapmorgan/php-code-fixer",
+          "namespace": "tools"
         }
       },
       "test": "phpcf -h"

--- a/tools.php
+++ b/tools.php
@@ -118,7 +118,7 @@ namespace Model {
 
         public function __toString(): string
         {
-            return sprintf('curl -Ls %s > %s && chmod +x %s', $this->phar, $this->bin, $this->bin);
+            return sprintf('curl -Ls -w %%{filename_effective}\'\n\' %s -o %s && chmod +x %s', $this->phar, $this->bin, $this->bin);
         }
     }
 
@@ -142,7 +142,7 @@ namespace Model {
 
         public function __toString(): string
         {
-            return sprintf('curl -Ls %s > %s', $this->url, $this->file);
+            return sprintf('curl -Ls -w %%{filename_effective}\'\n\' %s -o %s', $this->url, $this->file);
         }
     }
 

--- a/tools.php
+++ b/tools.php
@@ -173,16 +173,16 @@ namespace Model {
             return sprintf(
                 'cd $HOME && git clone %s && cd $HOME/%s && git checkout %s && composer install --no-dev --no-suggest --prefer-dist -n && box build && mv %s %s && chmod +x %s && cd && rm -rf $HOME/%s',
                 $this->repository,
-                $this->getTargetDir(),
+                $this->targetDir(),
                 $this->version ?? '$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null)',
                 $this->phar,
                 $this->bin,
                 $this->bin,
-                $this->getTargetDir()
+                $this->targetDir()
             );
         }
 
-        private function getTargetDir(): string
+        private function targetDir(): string
         {
             return preg_replace('#^.*/(.*?)(.git)?$#', '$1', $this->repository) ?? 'tmp';
         }
@@ -211,12 +211,12 @@ namespace Model {
             return sprintf(
                 'cd $HOME && git clone %s && cd $HOME/%s && git checkout %s && composer install --no-dev --no-suggest --prefer-dist -n',
                 $this->repository,
-                $this->getTargetDir(),
+                $this->targetDir(),
                 $this->version ?? '$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null)'
             );
         }
 
-        private function getTargetDir(): string
+        private function targetDir(): string
         {
             return preg_replace('#^.*/(.*?)(.git)?$#', '$1', $this->repository) ?? 'tmp';
         }
@@ -243,7 +243,7 @@ namespace Model {
             return sprintf('composer global require --no-suggest --prefer-dist --update-no-dev -n %s', $this->package);
         }
 
-        public function getPackage(): string
+        public function package(): string
         {
             return $this->package;
         }
@@ -616,7 +616,6 @@ namespace DocUpdate {
 namespace ToolsUpdate {
 
     use Model\Command;
-    use Model\MultiStepCommand;
     use Model\ShCommand;
 
     function FindLatestPharsCommand(string $jsonPath): Command


### PR DESCRIPTION
Fixes #56 

Phpstan extensions can now be installed with the bin plugin in the `phpstan` namespace:

```
composer global bin phpstan require phpstan/phpstan-phpunit
```

I also switched all `composer global install`s to the composer bin plugin as that doesn't make any difference in the image size.