### PR TITLE
Wrap alias in single quotes instead of double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ docker run -it --rm -v $(pwd):/project -v $(pwd)/tmp-phpqa:/tmp -w /project jakz
 You'll probably want to tweak this command for your needs and create an alias for convenience:
 
 ```bash
-alias phpqa="docker run -it --rm -v $(pwd):/project -v $(pwd)/tmp-phpqa:/tmp -w /project jakzal/phpqa:alpine"
+alias phpqa='docker run -it --rm -v $(pwd):/project -v $(pwd)/tmp-phpqa:/tmp -w /project jakzal/phpqa:alpine'
 ```
 
 Add it to your `~/.bashrc` so it's defined every time you start a new terminal session.


### PR DESCRIPTION
Single quotes are evaluated dynamically whilst double quotes are evaluated at time of creation and, thereafter, PWD never changes.

Tested on macOS adding alias to .zshrc
Tested on Ubuntu adding alias to .bashrc

On both cases only single quotes produce the desired outcome.