### PR TITLE
Do not parametrise nightly builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,14 @@ build-alpine:
 	docker build -f Dockerfile-alpine -t $(BUILD_TAG) .
 .PHONY: build-alpine
 
-build-nightly-latest: BUILD_TAG ?= jakzal/phpqa-nightly:$(shell date +%y%m%d)
 build-nightly-latest:
-	docker build -t $(BUILD_TAG) .
+	docker build -t jakzal/phpqa-nightly:$(shell date +%y%m%d) .
 	@docker login -u jakzal -p ${DOCKER_HUB_PASSWORD}
 	docker push $(BUILD_TAG)
 .PHONY: build-nightly-latest
 
-build-nightly-alpine: BUILD_TAG ?= jakzal/phpqa-nightly:$(shell date +%y%m%d)-alpine
 build-nightly-alpine:
-	docker build -f Dockerfile-alpine -t $(BUILD_TAG) .
+	docker build -f Dockerfile-alpine -t jakzal/phpqa-nightly:$(shell date +%y%m%d)-alpine .
 	@docker login -u jakzal -p ${DOCKER_HUB_PASSWORD}
 	docker push $(BUILD_TAG)
 .PHONY: build-nightly-alpine


### PR DESCRIPTION
The most recently nightly tag wasn't pushed as the build tag was overwritten.