### PR TITLE
Default to "WORKDIR /project" which allows to omit it from command args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:7.2-cli
 
 LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
+WORKDIR /project
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c unzip"

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,6 +1,7 @@
 FROM php:7.2-alpine
 
 LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
+WORKDIR /project
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkgconf re2c unzip"

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ If you want to be able to interrupt the selected tool if it takes too much time 
 `--init` option. Please refer to the [docker run documentation](https://docs.docker.com/engine/reference/commandline/run/) for more information.
 
 ```bash
-docker run --init -it --rm -v $(pwd):/project -v $(pwd)/tmp-phpqa:/tmp -w /project jakzal/phpqa phpstan analyse src
+docker run --init -it --rm -v $(pwd):/project -v $(pwd)/tmp-phpqa:/tmp jakzal/phpqa phpstan analyse src
 ```
 
 You'll probably want to tweak this command for your needs and create an alias for convenience:
 
 ```bash
-alias phpqa='docker run --init -it --rm -v $(pwd):/project -v $(pwd)/tmp-phpqa:/tmp -w /project jakzal/phpqa:alpine'
+alias phpqa='docker run --init -it --rm -v $(pwd):/project -v $(pwd)/tmp-phpqa:/tmp jakzal/phpqa:alpine'
 ```
 
 Add it to your `~/.bashrc` so it's defined every time you start a new terminal session.
@@ -135,7 +135,7 @@ docker build -t foo/phpqa .
 Finally, use your customised image instead of the default one:
 
 ```
-docker run --init -it --rm -v $(pwd):/project -w /project foo/phpqa phpmetrics .
+docker run --init -it --rm -v $(pwd):/project foo/phpqa phpmetrics .
 ```
 
 ### Adding PHPStan extensions


### PR DESCRIPTION
Since WORKDIR is most often not expected to change, it makes sense to provide the default value and simplify the execution a bit.

