### PR TITLE
add CoverageChecker

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -578,7 +578,7 @@
       "test": "testability --help"
     },
     {
-      "name": "CoverageChecker",
+      "name": "diffFilter",
       "summary": "Applies QA tools to run on a single pull request",
       "website": "https://github.com/exussum12/coverageChecker",
       "command": {

--- a/tools.json
+++ b/tools.json
@@ -583,7 +583,7 @@
       "website": "https://github.com/exussum12/coverageChecker",
       "command": {
         "composer-bin-plugin": {
-          "package": "exussum12/coverageChecker:dev-master",
+          "package": "exussum12/coverage-checker:dev-master",
           "namespace": "tools"
         }
       },

--- a/tools.json
+++ b/tools.json
@@ -583,7 +583,7 @@
       "website": "https://github.com/exussum12/coverageChecker",
       "command": {
         "composer-bin-plugin": {
-          "package": "exussum12/coverage-checker:dev-master",
+          "package": "exussum12/coverage-checker",
           "namespace": "tools"
         }
       },

--- a/tools.json
+++ b/tools.json
@@ -576,6 +576,18 @@
         }
       },
       "test": "testability --help"
+    },
+    {
+      "name": "CoverageChecker",
+      "summary": "Applies QA tools to run on a single pull request",
+      "website": "https://github.com/exussum12/coverageChecker",
+      "command": {
+        "composer-bin-plugin": {
+          "package": "exussum12/coverageChecker:dev-master",
+          "namespace": "tools"
+        }
+      },
+      "test": "diffFilter -v"
     }
   ]
 }


### PR DESCRIPTION
CoverageChecker allows QA tools to run on a single pull request.
This allows running these tools on a large legacy code base without having to fix all of the outstanding issues. Only the code you change needs to conform to the standard selected

Eg PSR-2 check only on changed code, or ensure every pull request has a test covering the new code


Edit:

Sorry opened a new PR the last commit didnt seem to come though - this is the same branch but it works fine now ?