### PR TITLE
add pcntl for phpcs parallel feature

### DIFF
--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -17,7 +17,7 @@ COPY --from=composer:1.7 /usr/bin/composer /usr/bin/composer
 RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
- && docker-php-ext-install zip \
+ && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/7.1/debian/Dockerfile
+++ b/7.1/debian/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=composer:1.7 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
- && docker-php-ext-install zip \
+ && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -17,7 +17,7 @@ COPY --from=composer:1.7 /usr/bin/composer /usr/bin/composer
 RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
- && docker-php-ext-install zip \
+ && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=composer:1.7 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
- && docker-php-ext-install zip \
+ && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/7.3/alpine/Dockerfile
+++ b/7.3/alpine/Dockerfile
@@ -17,7 +17,7 @@ COPY --from=composer:1.7 /usr/bin/composer /usr/bin/composer
 RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
- && docker-php-ext-install zip \
+ && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/7.3/debian/Dockerfile
+++ b/7.3/debian/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=composer:1.7 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
- && docker-php-ext-install zip \
+ && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -17,7 +17,7 @@ COPY --from=composer:1.7 /usr/bin/composer /usr/bin/composer
 RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
- && docker-php-ext-install zip \
+ && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -16,7 +16,7 @@ COPY --from=composer:1.7 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
- && docker-php-ext-install zip \
+ && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \


### PR DESCRIPTION
PHPCS set parallel to 1 if `pcntl` php extension is not installed. see https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Runner.php#L379

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

