### PR TITLE
make simple-phpunit dir writeable

### DIFF
--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
+ && chmod -R a+w $COMPOSER_HOME/vendor-bin/symfony/vendor/bin \
  && rm -rf ~/.composer/cache \
  && apk del .build-deps
 

--- a/7.1/debian/Dockerfile
+++ b/7.1/debian/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUI
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
+ && chmod -R a+w $COMPOSER_HOME/vendor-bin/symfony/vendor/bin \
  && rm -rf ~/.composer/cache \
  && apt-get purge -y --auto-remove $BUILD_DEPS
 

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
+ && chmod -R a+w $COMPOSER_HOME/vendor-bin/symfony/vendor/bin \
  && rm -rf ~/.composer/cache \
  && apk del .build-deps
 

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUI
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
+ && chmod -R a+w $COMPOSER_HOME/vendor-bin/symfony/vendor/bin \
  && rm -rf ~/.composer/cache \
  && apt-get purge -y --auto-remove $BUILD_DEPS
 

--- a/7.3/alpine/Dockerfile
+++ b/7.3/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
+ && chmod -R a+w $COMPOSER_HOME/vendor-bin/symfony/vendor/bin \
  && rm -rf ~/.composer/cache \
  && apk del .build-deps
 

--- a/7.3/debian/Dockerfile
+++ b/7.3/debian/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUI
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
+ && chmod -R a+w $COMPOSER_HOME/vendor-bin/symfony/vendor/bin \
  && rm -rf ~/.composer/cache \
  && apt-get purge -y --auto-remove $BUILD_DEPS
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -23,6 +23,7 @@ RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
+ && chmod -R a+w $COMPOSER_HOME/vendor-bin/symfony/vendor/bin \
  && rm -rf ~/.composer/cache \
  && apk del .build-deps
 

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUI
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
+ && chmod -R a+w $COMPOSER_HOME/vendor-bin/symfony/vendor/bin \
  && rm -rf ~/.composer/cache \
  && apt-get purge -y --auto-remove $BUILD_DEPS
 


### PR DESCRIPTION
fixes #110 

added `-R` to make the default installation writeable too.