### PR TITLE
Toolbox update

### DIFF
--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.1"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.2.6"
+ENV TOOLBOX_VERSION="1.3.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.1/debian/Dockerfile
+++ b/7.1/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.1"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.2.6"
+ENV TOOLBOX_VERSION="1.3.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.2"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.2.6"
+ENV TOOLBOX_VERSION="1.3.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.2"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.2.6"
+ENV TOOLBOX_VERSION="1.3.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.3/alpine/Dockerfile
+++ b/7.3/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.2.6"
+ENV TOOLBOX_VERSION="1.3.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.3/debian/Dockerfile
+++ b/7.3/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.2.6"
+ENV TOOLBOX_VERSION="1.3.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.2.6"
+ENV TOOLBOX_VERSION="1.3.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.2.6"
+ENV TOOLBOX_VERSION="1.3.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Nightly builds: https://hub.docker.com/r/jakzal/phpqa-nightly/
 * phpunit-7 - [The PHP testing framework (7.x version)](https://phpunit.de/)
 * psalm - [Finds errors in PHP applications](https://getpsalm.org/)
 * psecio-parse - [Scans code for potential security-related issues](https://github.com/psecio/parse)
+* roave-backward-compatibility-check - [Tool to compare two revisions of a class API to check for BC breaks](https://github.com/Roave/BackwardCompatibilityCheck)
 * security-checker - [Checks composer dependencies for known security vulnerabilities](https://github.com/sensiolabs/security-checker)
 * simple-phpunit - [Provides utilities to report legacy tests and usage of deprecated code](https://symfony.com/doc/current/components/phpunit_bridge.html)
 * testability - [Analyses and reports testability issues of a php codebase](https://github.com/edsonmedina/php_testability)

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ Nightly builds: https://hub.docker.com/r/jakzal/phpqa-nightly/
 ### Debian
 
 * `latest` ([7.3/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/master/7.3/debian/Dockerfile))
-* `1.17.1`, `1.17` ([7.3/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.17.1/7.3/debian/Dockerfile))
-* `1.17.1-php7.1`, `1.17-php7.1`, `php7.1` ([7.1/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.17.1/7.1/debian/Dockerfile))
-* `1.17.1-php7.2`, `1.17-php7.2`, `php7.2` ([7.2/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.17.1/7.2/debian/Dockerfile))
-* `1.17.1-php7.3`, `1.17-php7.3`, `php7.3` ([7.3/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.17.1/7.3/debian/Dockerfile))
+* `1.18.0`, `1.18` ([7.3/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.18.0/7.3/debian/Dockerfile))
+* `1.18.0-php7.1`, `1.18-php7.1`, `php7.1` ([7.1/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.18.0/7.1/debian/Dockerfile))
+* `1.18.0-php7.2`, `1.18-php7.2`, `php7.2` ([7.2/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.18.0/7.2/debian/Dockerfile))
+* `1.18.0-php7.3`, `1.18-php7.3`, `php7.3` ([7.3/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.18.0/7.3/debian/Dockerfile))
 
 ### Alpine
 
 * `alpine` ([7.3/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/master/7.3/alpine/Dockerfile))
-* `1.17.1-alpine`, `1.17-alpine`, ([7.3/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.17.1/7.3/alpine/Dockerfile))
-* `1.17.1-php7.1-alpine`, `1.17-php7.1-alpine`, `php7.1-alpine` ([7.1/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.17.1/7.1/alpine/Dockerfile))
-* `1.17.1-php7.2-alpine`, `1.17-php7.2-alpine`, `php7.2-alpine` ([7.2/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.17.1/7.2/alpine/Dockerfile))
-* `1.17.1-php7.3-alpine`, `1.17-php7.3-alpine`, `php7.3-alpine` ([7.3/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.17.1/7.3/alpine/Dockerfile))
+* `1.18.0-alpine`, `1.18-alpine`, ([7.3/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.18.0/7.3/alpine/Dockerfile))
+* `1.18.0-php7.1-alpine`, `1.18-php7.1-alpine`, `php7.1-alpine` ([7.1/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.18.0/7.1/alpine/Dockerfile))
+* `1.18.0-php7.2-alpine`, `1.18-php7.2-alpine`, `php7.2-alpine` ([7.2/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.18.0/7.2/alpine/Dockerfile))
+* `1.18.0-php7.3-alpine`, `1.18-php7.3-alpine`, `php7.3-alpine` ([7.3/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.18.0/7.3/alpine/Dockerfile))
 
 ## Available tools
 


### PR DESCRIPTION
New tools:

* roave-backward-compatibility-check - [Tool to compare two revisions of a class API to check for BC breaks](https://github.com/Roave/BackwardCompatibilityCheck)

Updates:

* phan (1.2.4 -> 1.2.5)
* psalm (3.0.17 -> 3.1.0)