### PR TITLE
Update toolbox 1.3.0 -> 1.4.0

### DIFF
--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.1"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.3.0"
+ENV TOOLBOX_VERSION="1.4.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.1/debian/Dockerfile
+++ b/7.1/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.1"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.3.0"
+ENV TOOLBOX_VERSION="1.4.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.2"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.3.0"
+ENV TOOLBOX_VERSION="1.4.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.2"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.3.0"
+ENV TOOLBOX_VERSION="1.4.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.3/alpine/Dockerfile
+++ b/7.3/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.3.0"
+ENV TOOLBOX_VERSION="1.4.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.3/debian/Dockerfile
+++ b/7.3/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.3.0"
+ENV TOOLBOX_VERSION="1.4.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.3.0"
+ENV TOOLBOX_VERSION="1.4.0"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/Dockerfile-debian.bkp
+++ b/Dockerfile-debian.bkp
@@ -1,21 +1,20 @@
-FROM php:7.3-alpine
+FROM php:7.3-cli
 
 LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
 
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev pkgconf re2c"
-ENV LIB_DEPS="zlib-dev libzip-dev"
+ENV BUILD_DEPS="autoconf file g++ gcc libc-dev pkg-config re2c"
+ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.4.0"
-ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
+ENV TOOLBOX_VERSION="1.3.0"
+ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer
 
 COPY --from=composer:1.8 /usr/bin/composer /usr/bin/composer
 
-RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
- && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
+RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
  && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
@@ -24,6 +23,6 @@ RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf ~/.composer/cache \
- && apk del .build-deps
+ && apt-get purge -y --auto-remove $BUILD_DEPS
 
 CMD php $TOOLBOX_TARGET_DIR/toolbox list-tools


### PR DESCRIPTION
:robot: This pull request was automagically sent from [Travis CI](https://travis-ci.org/jakzal/phpqa/builds/507964282).



New tools:



* rector - [Tool for instant code upgrades and refactoring](https://github.com/rectorphp/rector) #61 

* paratest - [Parallel testing for PHPUnit](https://github.com/paratestphp/paratest) #62 

* phpstan-localheinz-rules - [Additional rules for PHPstan](https://github.com/localheinz/phpstan-rules) #63 

* composer-normalize - [Composer plugin to normalize composer.json files](https://github.com/localheinz/composer-normalize) #64 



Updates:



* psalm (3.1.0 -> 3.1.1) #59