### PR TITLE
Update toolbox 1.4.4 -> 1.4.5

### DIFF
--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.1"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.4.4"
+ENV TOOLBOX_VERSION="1.4.5"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.1/debian/Dockerfile
+++ b/7.1/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.1"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.4.4"
+ENV TOOLBOX_VERSION="1.4.5"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.2"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.4.4"
+ENV TOOLBOX_VERSION="1.4.5"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.2"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.4.4"
+ENV TOOLBOX_VERSION="1.4.5"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.3/alpine/Dockerfile
+++ b/7.3/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.4.4"
+ENV TOOLBOX_VERSION="1.4.5"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.3/debian/Dockerfile
+++ b/7.3/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.4.4"
+ENV TOOLBOX_VERSION="1.4.5"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.4.4"
+ENV TOOLBOX_VERSION="1.4.5"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.4.4"
+ENV TOOLBOX_VERSION="1.4.5"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:/tools/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer


### PR DESCRIPTION
Updates:

* Install phpda with composer-bin-plugin https://github.com/jakzal/toolbox/pull/81
* Install tools requiring a legacy nikic/php-parser in their own namespace https://github.com/jakzal/toolbox/pull/81
* Move php-coupling-detector and php-assumptions back to the tools namespace https://github.com/jakzal/toolbox/pull/81
