### PR TITLE
Include pcov

### DIFF
--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -17,10 +17,12 @@ COPY --from=composer:1.9 /usr/bin/composer /usr/bin/composer
 RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
+ && pecl install pcov && docker-php-ext-enable pcov \
  && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
+ && echo "pcov.enabled=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf $COMPOSER_HOME/cache \

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -16,10 +16,12 @@ COPY --from=composer:1.9 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
+ && pecl install pcov && docker-php-ext-enable pcov \
  && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
+ && echo "pcov.enabled=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf $COMPOSER_HOME/cache \

--- a/7.3/alpine/Dockerfile
+++ b/7.3/alpine/Dockerfile
@@ -17,10 +17,12 @@ COPY --from=composer:1.9 /usr/bin/composer /usr/bin/composer
 RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
+ && pecl install pcov && docker-php-ext-enable pcov \
  && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
+ && echo "pcov.enabled=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf $COMPOSER_HOME/cache \

--- a/7.3/debian/Dockerfile
+++ b/7.3/debian/Dockerfile
@@ -16,10 +16,12 @@ COPY --from=composer:1.9 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
+ && pecl install pcov && docker-php-ext-enable pcov \
  && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
+ && echo "pcov.enabled=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf $COMPOSER_HOME/cache \

--- a/7.4/alpine/Dockerfile
+++ b/7.4/alpine/Dockerfile
@@ -17,10 +17,12 @@ COPY --from=composer:1.9 /usr/bin/composer /usr/bin/composer
 RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
+ && pecl install pcov && docker-php-ext-enable pcov \
  && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
+ && echo "pcov.enabled=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf $COMPOSER_HOME/cache \

--- a/7.4/debian/Dockerfile
+++ b/7.4/debian/Dockerfile
@@ -16,10 +16,12 @@ COPY --from=composer:1.9 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
+ && pecl install pcov && docker-php-ext-enable pcov \
  && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
+ && echo "pcov.enabled=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf $COMPOSER_HOME/cache \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -17,10 +17,12 @@ COPY --from=composer:1.9 /usr/bin/composer /usr/bin/composer
 RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
+ && pecl install pcov && docker-php-ext-enable pcov \
  && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
+ && echo "pcov.enabled=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf $COMPOSER_HOME/cache \

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -16,10 +16,12 @@ COPY --from=composer:1.9 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
+ && pecl install pcov && docker-php-ext-enable pcov \
  && docker-php-ext-install zip pcntl \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \
+ && echo "pcov.enabled=0" >> $PHP_INI_DIR/php.ini \
  && mkdir -p $TOOLBOX_TARGET_DIR && curl -Ls https://github.com/jakzal/toolbox/releases/download/v$TOOLBOX_VERSION/toolbox.phar -o $TOOLBOX_TARGET_DIR/toolbox && chmod +x $TOOLBOX_TARGET_DIR/toolbox \
  && php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf $COMPOSER_HOME/cache \

--- a/README.md
+++ b/README.md
@@ -280,10 +280,22 @@ includes:
 
 ## Debugger & Code Coverage
 
-The [php-dbg debugger](http://php.net/manual/en/debugger-about.php) is provided by default. No additional extensions (like XDebug) are required to calculate code coverage:
+The [pcov](https://github.com/krakjoe/pcov) code coverage extension,
+as well as the [php-dbg debugger](http://php.net/manual/en/debugger-about.php),
+are provided on the image out of the box.
+
+pcov is disabled by default so it doesn't affect performance when it's not needed,
+and doesn't break interoperability with other coverage extensions.
+It can be enabled by setting `pcov.enabled=1`:
 
 ```
-phpqa phpdbg -qrr ./vendor/bin/phpunit --coverage-text
+phpqa php -d pcov.enabled=1 ./vendor/bin/phpunit --coverage-text
+```
+
+Infection users will need to define initial php options:
+
+```
+phpqa /tools/infection run --initial-tests-php-options='-dpcov.enabled=1'
 ```
 
 ## Contributing


### PR DESCRIPTION
Fixes #183 

pcov is disabled by default so it doesn't affect performance when it's not needed,
and doesn't break interoperability with other coverage extensions.
It can be enabled by setting `pcov.enabled=1`:

 ```
phpqa php -d pcov.enabled=1 ./vendor/bin/phpunit --coverage-text
```

<img width="603" alt="image" src="https://user-images.githubusercontent.com/190447/74155576-b8162900-4c0c-11ea-97c2-6bbd2389bc98.png">

```
phpqa /tools/infection run --initial-tests-php-options='-dpcov.enabled=1'
```

<img width="585" alt="image" src="https://user-images.githubusercontent.com/190447/74158249-a71be680-4c11-11ea-95b5-0501fea9cefd.png">

<img width="745" alt="image" src="https://user-images.githubusercontent.com/190447/74157866-f281c500-4c10-11ea-9ab4-62cd4f403fe9.png">
