### PR TITLE
Add intl extension

### DIFF
--- a/7.3/alpine/Dockerfile
+++ b/7.3/alpine/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
  && pecl install pcov && docker-php-ext-enable pcov \
- && docker-php-ext-install zip pcntl bz2 \
+ && docker-php-ext-install zip pcntl intl bz2 \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/7.3/debian/Dockerfile
+++ b/7.3/debian/Dockerfile
@@ -17,7 +17,7 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
  && pecl install pcov && docker-php-ext-enable pcov \
- && docker-php-ext-install zip pcntl bz2 \
+ && docker-php-ext-install zip pcntl intl bz2 \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/7.4/alpine/Dockerfile
+++ b/7.4/alpine/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
  && pecl install pcov && docker-php-ext-enable pcov \
- && docker-php-ext-install zip pcntl bz2 \
+ && docker-php-ext-install zip pcntl intl bz2 \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/7.4/debian/Dockerfile
+++ b/7.4/debian/Dockerfile
@@ -17,7 +17,7 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
  && pecl install pcov && docker-php-ext-enable pcov \
- && docker-php-ext-install zip pcntl bz2 \
+ && docker-php-ext-install zip pcntl intl bz2 \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
  && pecl install pcov && docker-php-ext-enable pcov \
- && docker-php-ext-install zip pcntl bz2 \
+ && docker-php-ext-install zip pcntl intl bz2 \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -17,7 +17,7 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
  && pecl install pcov && docker-php-ext-enable pcov \
- && docker-php-ext-install zip pcntl bz2 \
+ && docker-php-ext-install zip pcntl intl bz2 \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -3,7 +3,7 @@ FROM php:7.4-alpine
 LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
 
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev pkgconf re2c"
-ENV LIB_DEPS="zlib-dev libzip-dev bzip2-dev"
+ENV LIB_DEPS="zlib-dev libzip-dev bzip2-dev icu-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -18,7 +18,7 @@ RUN apk add --no-cache --virtual .tool-deps $TOOL_DEPS $LIB_DEPS \
  && apk add --no-cache --virtual .build-deps $BUILD_DEPS \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
  && pecl install pcov && docker-php-ext-enable pcov \
- && docker-php-ext-install zip pcntl bz2 \
+ && docker-php-ext-install zip pcntl intl bz2 \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -3,7 +3,7 @@ FROM php:7.4-cli
 LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
 
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev pkg-config re2c"
-ENV LIB_DEPS="zlib1g-dev libzip-dev libbz2-dev"
+ENV LIB_DEPS="zlib1g-dev libzip-dev libbz2-dev libicu-dev"
 ENV TOOL_DEPS="git graphviz make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -17,7 +17,7 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 RUN apt-get update && apt-get install -y --no-install-recommends $TOOL_DEPS $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/* \
  && git clone https://github.com/nikic/php-ast.git && cd php-ast && phpize && ./configure && make && make install && cd .. && rm -rf php-ast && docker-php-ext-enable ast \
  && pecl install pcov && docker-php-ext-enable pcov \
- && docker-php-ext-install zip pcntl bz2 \
+ && docker-php-ext-install zip pcntl intl bz2 \
  && echo "date.timezone=Europe/London" >> $PHP_INI_DIR/php.ini \
  && echo "memory_limit=-1" >> $PHP_INI_DIR/php.ini \
  && echo "phar.readonly=0" >> $PHP_INI_DIR/php.ini \


### PR DESCRIPTION
Latest version of Rector complains about missing `intl` extension. I would consider it reasonable to add this to the PHP builds.

`Notice: RectorPrefix20210124\Nette\Utils\Strings::toAscii(): it is recommended to enable PHP extensions 'intl'. in /tools/.composer/vendor-bin/rector/vendor/rector/rector-prefixed/vendor/nette/utils/src/Utils/Strings.php on line 124`