### PR TITLE
Add fonts required for graphviz on alpine

### DIFF
--- a/7.3/alpine/Dockerfile
+++ b/7.3/alpine/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
 
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev pkgconf re2c"
 ENV LIB_DEPS="zlib-dev libzip-dev bzip2-dev icu-dev"
-ENV TOOL_DEPS="git graphviz make unzip"
+ENV TOOL_DEPS="git graphviz ttf-freefont make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
 ENV TOOLBOX_VERSION="1.42.0"

--- a/7.4/alpine/Dockerfile
+++ b/7.4/alpine/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
 
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev pkgconf re2c"
 ENV LIB_DEPS="zlib-dev libzip-dev bzip2-dev icu-dev"
-ENV TOOL_DEPS="git graphviz make unzip"
+ENV TOOL_DEPS="git graphviz ttf-freefont make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.4"
 ENV TOOLBOX_TARGET_DIR="/tools"
 ENV TOOLBOX_VERSION="1.42.0"

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
 
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev pkgconf re2c"
 ENV LIB_DEPS="zlib-dev libzip-dev bzip2-dev icu-dev"
-ENV TOOL_DEPS="git graphviz make unzip"
+ENV TOOL_DEPS="git graphviz ttf-freefont make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:8.0"
 ENV TOOLBOX_TARGET_DIR="/tools"
 ENV TOOLBOX_VERSION="1.42.0"

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -4,7 +4,7 @@ LABEL maintainer="Jakub Zalas <jakub@zalas.pl>"
 
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev pkgconf re2c"
 ENV LIB_DEPS="zlib-dev libzip-dev bzip2-dev icu-dev"
-ENV TOOL_DEPS="git graphviz make unzip"
+ENV TOOL_DEPS="git graphviz ttf-freefont make unzip"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
 ENV TOOLBOX_VERSION="1.42.0"


### PR DESCRIPTION
Images generated with alpine graphviz (with `deptrac`) have squares instead of characters. Installing `ttf-freefont` fixes it
Before:
![g](https://user-images.githubusercontent.com/3062750/111545510-74c6ac00-8776-11eb-8e6a-e0311cc2b7b2.png)
After
![ga](https://user-images.githubusercontent.com/3062750/111545562-8740e580-8776-11eb-9cf0-9e099965f402.png)

