### PR TITLE
Update toolbox 1.45.0 -> 1.45.4

### DIFF
--- a/7.3/alpine/Dockerfile
+++ b/7.3/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev bzip2-dev icu-dev"
 ENV TOOL_DEPS="git graphviz ttf-freefont make unzip gpgme"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.45.0"
+ENV TOOLBOX_VERSION="1.45.4"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:$TOOLBOX_TARGET_DIR/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.3/debian/Dockerfile
+++ b/7.3/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev libbz2-dev libicu-dev"
 ENV TOOL_DEPS="git graphviz make unzip gpg"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.45.0"
+ENV TOOLBOX_VERSION="1.45.4"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:$TOOLBOX_TARGET_DIR/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.4/alpine/Dockerfile
+++ b/7.4/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev bzip2-dev icu-dev"
 ENV TOOL_DEPS="git graphviz ttf-freefont make unzip gpgme"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.4"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.45.0"
+ENV TOOLBOX_VERSION="1.45.4"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:$TOOLBOX_TARGET_DIR/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/7.4/debian/Dockerfile
+++ b/7.4/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev libbz2-dev libicu-dev"
 ENV TOOL_DEPS="git graphviz make unzip gpg"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.4"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.45.0"
+ENV TOOLBOX_VERSION="1.45.4"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:$TOOLBOX_TARGET_DIR/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev bzip2-dev icu-dev"
 ENV TOOL_DEPS="git graphviz ttf-freefont make unzip gpgme"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:8.0"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.45.0"
+ENV TOOLBOX_VERSION="1.45.4"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:$TOOLBOX_TARGET_DIR/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev libbz2-dev libicu-dev"
 ENV TOOL_DEPS="git graphviz make unzip gpg"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:8.0"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.45.0"
+ENV TOOLBOX_VERSION="1.45.4"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:$TOOLBOX_TARGET_DIR/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib-dev libzip-dev bzip2-dev icu-dev"
 ENV TOOL_DEPS="git graphviz ttf-freefont make unzip gpgme"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.45.0"
+ENV TOOLBOX_VERSION="1.45.4"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:$TOOLBOX_TARGET_DIR/.composer/vendor/bin:$TOOLBOX_TARGET_DIR/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -7,7 +7,7 @@ ENV LIB_DEPS="zlib1g-dev libzip-dev libbz2-dev libicu-dev"
 ENV TOOL_DEPS="git graphviz make unzip gpg"
 ENV TOOLBOX_EXCLUDED_TAGS="exclude-php:7.3"
 ENV TOOLBOX_TARGET_DIR="/tools"
-ENV TOOLBOX_VERSION="1.45.0"
+ENV TOOLBOX_VERSION="1.45.4"
 ENV PATH="$PATH:$TOOLBOX_TARGET_DIR:$TOOLBOX_TARGET_DIR/.composer/vendor/bin:/tools/QualityAnalyzer/bin:$TOOLBOX_TARGET_DIR/DesignPatternDetector/bin:$TOOLBOX_TARGET_DIR/EasyCodingStandard/bin"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME=$TOOLBOX_TARGET_DIR/.composer

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ Nightly builds: https://hub.docker.com/r/jakzal/phpqa-nightly/
 ### Debian
 
 * `latest` ([8.0/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/master/8.0/debian/Dockerfile))
-* `1.55.0`, `1.55` ([8.0/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.0/8.0/debian/Dockerfile))
-* `1.55.0-php7.3`, `1.55-php7.3`, `php7.3` ([7.3/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.0/7.3/debian/Dockerfile))
-* `1.55.0-php7.4`, `1.55-php7.4`, `php7.4` ([7.4/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.0/7.4/debian/Dockerfile))
-* `1.55.0-php8.0`, `1.55-php8.0`, `php8.0` ([8.0/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.0/8.0/debian/Dockerfile))
+* `1.55.1`, `1.55` ([8.0/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.1/8.0/debian/Dockerfile))
+* `1.55.1-php7.3`, `1.55-php7.3`, `php7.3` ([7.3/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.1/7.3/debian/Dockerfile))
+* `1.55.1-php7.4`, `1.55-php7.4`, `php7.4` ([7.4/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.1/7.4/debian/Dockerfile))
+* `1.55.1-php8.0`, `1.55-php8.0`, `php8.0` ([8.0/debian/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.1/8.0/debian/Dockerfile))
 
 ### Alpine
 
 * `alpine` ([8.0/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/master/8.0/alpine/Dockerfile))
-* `1.55.0-alpine`, `1.55-alpine`, ([8.0/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.0/8.0/alpine/Dockerfile))
-* `1.55.0-php7.3-alpine`, `1.55-php7.3-alpine`, `php7.3-alpine` ([7.3/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.0/7.3/alpine/Dockerfile))
-* `1.55.0-php7.4-alpine`, `1.55-php7.4-alpine`, `php7.4-alpine` ([7.4/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.0/7.4/alpine/Dockerfile))
-* `1.55.0-php8.0-alpine`, `1.55-php8.0-alpine`, `php8.0-alpine` ([8.0/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.0/8.0/alpine/Dockerfile))
+* `1.55.1-alpine`, `1.55-alpine`, ([8.0/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.1/8.0/alpine/Dockerfile))
+* `1.55.1-php7.3-alpine`, `1.55-php7.3-alpine`, `php7.3-alpine` ([7.3/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.1/7.3/alpine/Dockerfile))
+* `1.55.1-php7.4-alpine`, `1.55-php7.4-alpine`, `php7.4-alpine` ([7.4/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.1/7.4/alpine/Dockerfile))
+* `1.55.1-php8.0-alpine`, `1.55-php8.0-alpine`, `php8.0-alpine` ([8.0/alpine/Dockerfile](https://github.com/jakzal/phpqa/blob/v1.55.1/8.0/alpine/Dockerfile))
 
 ### Legacy
 


### PR DESCRIPTION
:robot: This pull request was automagically sent from a Github action.



Rebuild the phar with latest box, scoper, and Symfony polyfills whitelisted.