### PR TITLE
doc/cookbook with two first recipes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,10 @@ Infection users will need to define initial php options:
 phpqa /tools/infection run --initial-tests-php-options='-dpcov.enabled=1'
 ```
 
+## Cookbook
+
+Please check out the [cookbook](docs/cookbook/README.md) for further tips & tricks.
+
 ## Contributing
 
 Please read the [Contributing guide](CONTRIBUTING.md) to learn about contributing to this project.

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -1,0 +1,10 @@
+# Cookbook
+
+Here you will find a list of tips & tricks that are to long to be put in the default README.
+
+## Index
+
+- [Install AMPQ in PHPQA](ampq.md)
+- [Install Xdebug in PHPQA](xdebug.md)
+
+

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -1,6 +1,6 @@
 # Cookbook
 
-Here you will find a list of tips & tricks that are to long to be put in the default README.
+Here you will find a list of tips & tricks that are too long to be put in the main README.
 
 ## Index
 

--- a/docs/cookbook/ampq.md
+++ b/docs/cookbook/ampq.md
@@ -1,5 +1,7 @@
 # AMPQ
 
+*Contributed by [dgoosens](https://github.com/dgoosens).*
+
 Some extension do take a little time before they are ready for the latest and greatest version of PHP.
 If you really need those extensions and can not wait, you will have to compile them yourself.
 

--- a/docs/cookbook/ampq.md
+++ b/docs/cookbook/ampq.md
@@ -1,0 +1,65 @@
+# AMPQ
+
+Some extension do take a little time before they are ready for the latest and greatest version of PHP.
+If you really need those extensions and can not wait, you will have to compile them yourself.
+
+This can easily be done with PHPQA as well.
+
+*The procedure below uses a [Docker MultiStage Build](https://docs.docker.com/develop/develop-images/multistage-build/) and the resulting build will therefore barely be any bigger than the original PHPQA.*
+
+As instructed in the global [README](https://github.com/jakzal/phpqa#customising-the-image), one has to create a new `Dockerfile` to customize it.
+
+## Debian Dockerfile
+
+```Dockerfile
+FROM jakzal/phpqa:debian AS ext-amqp
+ENV EXT_AMQP_VERSION=master
+
+RUN docker-php-source extract
+RUN apt-get update
+RUN apt-get install -qq -y build-essential autoconf librabbitmq-dev
+RUN git clone --branch $EXT_AMQP_VERSION --depth 1 https://github.com/php-amqp/php-amqp.git /usr/src/php/ext/amqp
+RUN cd /usr/src/php/ext/amqp && git submodule update --init
+RUN docker-php-ext-install amqp
+
+RUN ls -al /usr/local/lib/php/extensions/
+
+FROM jakzal/phpqa:debian
+
+COPY --from=ext-amqp /usr/local/etc/php/conf.d/docker-php-ext-amqp.ini /usr/local/etc/php/conf.d/docker-php-ext-amqp.ini
+COPY --from=ext-amqp /usr/local/lib/php/extensions/no-debug-non-zts-20210902/amqp.so /usr/local/lib/php/extensions/no-debug-non-zts-20210902/amqp.so
+
+RUN apt-get update
+RUN apt-get install -qq -y librabbitmq-dev
+```
+
+## Alpine Dockerfile
+
+```Dockerfile
+FROM jakzal/phpqa:alpine AS ext-amqp
+ENV EXT_AMQP_VERSION=master
+
+RUN docker-php-source extract
+RUN apk -Uu add rabbitmq-c-dev
+RUN git clone --branch $EXT_AMQP_VERSION --depth 1 https://github.com/php-amqp/php-amqp.git /usr/src/php/ext/amqp
+RUN cd /usr/src/php/ext/amqp && git submodule update --init
+RUN docker-php-ext-install amqp
+
+RUN ls -al /usr/local/lib/php/extensions/
+
+FROM jakzal/phpqa:alpine
+
+COPY --from=ext-amqp /usr/local/etc/php/conf.d/docker-php-ext-amqp.ini /usr/local/etc/php/conf.d/docker-php-ext-amqp.ini
+COPY --from=ext-amqp /usr/local/lib/php/extensions/no-debug-non-zts-20210902/amqp.so /usr/local/lib/php/extensions/no-debug-non-zts-20210902/amqp.so
+
+RUN apk -Uu add rabbitmq-c-dev
+```
+
+## About the extension path
+
+Please note that the `no-debug-non-zts-20210902` in the above extension path, that is copied, changes with every release...
+This is why the `RUN ls -al /usr/local/lib/php/extensions/` is issued as it will list the content of that directory and inform the user what the exact path should be.
+
+## Source
+
+Highly inspired by this [blog post](https://exploit.cz/how-to-compile-amqp-extension-for-php-8-0-via-multistage-dockerfile/) by Patrick from [exploit.cz](https://exploit.cz/)

--- a/docs/cookbook/ampq.md
+++ b/docs/cookbook/ampq.md
@@ -7,7 +7,7 @@ This can easily be done with PHPQA as well.
 
 *The procedure below uses a [Docker MultiStage Build](https://docs.docker.com/develop/develop-images/multistage-build/) and the resulting build will therefore barely be any bigger than the original PHPQA.*
 
-As instructed in the global [README](https://github.com/jakzal/phpqa#customising-the-image), one has to create a new `Dockerfile` to customize it.
+As instructed in the main [README](https://github.com/jakzal/phpqa#customising-the-image), one has to create a new `Dockerfile` to customize it.
 
 ## Debian Dockerfile
 

--- a/docs/cookbook/xdebug.md
+++ b/docs/cookbook/xdebug.md
@@ -1,0 +1,86 @@
+# Xdebug
+
+This procedure is similar to the one explained for [AMPQ](ampq.md).
+
+## Debian Dockerfile
+
+```Dockerfile
+FROM jakzal/phpqa:debian AS ext-xdebug
+
+RUN docker-php-source extract
+RUN apt-get update
+RUN apt-get install -qq -y build-essential autoconf 
+
+RUN pecl install xdebug
+RUN docker-php-ext-enable xdebug
+
+RUN ls -al /usr/local/lib/php/extensions/
+
+FROM jakzal/phpqa:debian
+
+COPY --from=ext-xdebug /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+COPY --from=ext-xdebug /usr/local/lib/php/extensions/no-debug-non-zts-20210902/xdebug.so /usr/local/lib/php/extensions/no-debug-non-zts-20210902/xdebug.so
+```
+
+## Alpine Dockerfile
+
+```Dockerfile
+FROM jakzal/phpqa:alpine AS ext-xdebug
+
+RUN docker-php-source extract
+RUN apk -Uu add autoconf build-base
+RUN pecl install xdebug
+RUN docker-php-ext-enable xdebug
+
+RUN ls -al /usr/local/lib/php/extensions/
+
+FROM jakzal/phpqa:alpine
+
+COPY --from=ext-xdebug /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+COPY --from=ext-xdebug /usr/local/lib/php/extensions/no-debug-non-zts-20210902/xdebug.so /usr/local/lib/php/extensions/no-debug-non-zts-20210902/xdebug.so
+```
+
+## About the extension path
+
+Please note that the `no-debug-non-zts-20210902` in the above extension path, that is copied, changes with every release...
+This is why the `RUN ls -al /usr/local/lib/php/extensions/` is issued as it will list the content of that directory and inform the user what the exact path should be.
+
+## Note
+
+If you need to include multiple extensions, you will have to bundle the commands together.  
+For instance, for [AMPQ](ampq.md) **AND** XDebug, the Debian `Dockerfile` will look like this:
+
+```Dockerfile
+FROM jakzal/phpqa:debian AS ext-multi
+ENV EXT_AMQP_VERSION=master
+
+RUN docker-php-source extract
+RUN apt-get update
+RUN apt-get install -qq -y build-essential autoconf 
+
+# xdebug
+RUN pecl install xdebug
+RUN docker-php-ext-enable xdebug
+
+# ampq
+RUN apt-get install -qq -y librabbitmq-dev
+RUN git clone --branch $EXT_AMQP_VERSION --depth 1 https://github.com/php-amqp/php-amqp.git /usr/src/php/ext/amqp
+RUN cd /usr/src/php/ext/amqp && git submodule update --init
+RUN docker-php-ext-install amqp
+
+
+RUN ls -al /usr/local/lib/php/extensions/
+
+FROM jakzal/phpqa:debian
+
+# xdebug
+COPY --from=ext-multi /usr/local/etc/php/conf.d/docker-php-ext-multi.ini /usr/local/etc/php/conf.d/docker-php-ext-multi.ini
+COPY --from=ext-multi /usr/local/lib/php/extensions/no-debug-non-zts-20210902/xdebug.so /usr/local/lib/php/extensions/no-debug-non-zts-20210902/xdebug.so
+
+# ampq
+COPY --from=ext-amqp /usr/local/etc/php/conf.d/docker-php-ext-amqp.ini /usr/local/etc/php/conf.d/docker-php-ext-amqp.ini
+COPY --from=ext-amqp /usr/local/lib/php/extensions/no-debug-non-zts-20210902/amqp.so /usr/local/lib/php/extensions/no-debug-non-zts-20210902/amqp.so
+RUN apt-get update
+RUN apt-get install -qq -y librabbitmq-dev
+```
+

--- a/docs/cookbook/xdebug.md
+++ b/docs/cookbook/xdebug.md
@@ -1,5 +1,7 @@
 # Xdebug
 
+*Contributed by [dgoosens](https://github.com/dgoosens).*
+
 This procedure is similar to the one explained for [AMPQ](ampq.md).
 
 ## Debian Dockerfile


### PR DESCRIPTION
hi @jakzal 

as discussed in #344 here are the first recipes  for the PHPQA Cookbook...  

it includes:

- cookbook for AMPQ extension
- cookbook for Xdebug
- index of the cookbook
- reference in the base README to the cookbook

dGo 