### PR TITLE
Add example for Gitlab CI

### DIFF
--- a/docs/cookbook/gitlab-ci.md
+++ b/docs/cookbook/gitlab-ci.md
@@ -1,0 +1,26 @@
+# Gitlab CI
+
+*Contributed by [RVxLab](https://github.com/RVxLab).*
+
+The example below demonstrates how phpqa can be used in the Gitlab CI.
+
+```yaml
+# .gitlab-ci.yml
+image: php:8.1-fpm-alpine3.15
+
+stages:
+    - style
+
+php-cs-fixer:
+    stage: style
+    image: jakzal/phpqa:php8.1-alpine
+    script:
+        - php-cs-fixer fix --dry-run --stop-on-violation
+
+phpstan:
+    stage: style
+    image: jakzal/phpqa:php8.1-alpine
+    script:
+      - phpstan analyze
+```
+


### PR DESCRIPTION
This PR adds a cookbook entry to show an example on how to use phpqa in Gitlab.
