### PR TITLE
Authenticate with Composer to avoid rate limiting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,7 @@ jobs:
                         INSTALLATION_DATE=${{ steps.version.outputs.date }}
                     secrets: |
                         "composer.auth={""github-oauth"":{""github.com"":""${{ secrets.GITHUB_TOKEN }}""} }"
+                        "phive.auth=<auth xmlns=""https://phar.io/auth""><domain host=""api.github.com"" type=""token"" credentials=""${{ secrets.GITHUB_TOKEN }}"" /></auth>"
                     labels: |
                         org.opencontainers.image.source=${{ github.event.repository.html_url }}
                         org.opencontainers.image.created=${{ steps.version.outputs.created }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,8 @@ jobs:
                     build-args: |
                         PHP_VERSION=${{ matrix.php }}
                         INSTALLATION_DATE=${{ steps.version.outputs.date }}
+                    secrets: |
+                        "composer.auth={""github-oauth"":{""github.com"":""${{ secrets.GITHUB_TOKEN }}""} }"
                     labels: |
                         org.opencontainers.image.source=${{ github.event.repository.html_url }}
                         org.opencontainers.image.created=${{ steps.version.outputs.created }}

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 ARG PHP_VERSION=8.1
 ARG BASE_IMAGE=php:${PHP_VERSION}-alpine
 ARG TOOLBOX_EXCLUDED_TAGS="exclude-php:${PHP_VERSION}"
@@ -46,10 +48,10 @@ COPY --from=toolbox /toolbox $TOOLBOX_TARGET_DIR/toolbox
 COPY --from=composer:2 /usr/bin/composer $TOOLBOX_TARGET_DIR/composer
 COPY entrypoint.sh /entrypoint.sh
 
-RUN php $TOOLBOX_TARGET_DIR/toolbox install \
+RUN --mount=type=secret,id=composer.auth,target=${COMPOSER_HOME}/auth.json \
+ php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf $COMPOSER_HOME/cache
 
 WORKDIR $TOOLBOX_TARGET_DIR
 ENTRYPOINT ["/entrypoint.sh"]
 CMD php $TOOLBOX_TARGET_DIR/toolbox list-tools
-

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -49,6 +49,7 @@ COPY --from=composer:2 /usr/bin/composer $TOOLBOX_TARGET_DIR/composer
 COPY entrypoint.sh /entrypoint.sh
 
 RUN --mount=type=secret,id=composer.auth,target=${COMPOSER_HOME}/auth.json \
+ --mount=type=secret,id=phive.auth,target=${TOOLBOX_TARGET_DIR}/.phive/auth.xml \
  php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf $COMPOSER_HOME/cache
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 ARG PHP_VERSION=8.1
 ARG BASE_IMAGE=php:${PHP_VERSION}-cli
 ARG TOOLBOX_EXCLUDED_TAGS="exclude-php:${PHP_VERSION}"
@@ -45,7 +47,8 @@ COPY --from=toolbox /toolbox $TOOLBOX_TARGET_DIR/toolbox
 COPY --from=composer:2 /usr/bin/composer $TOOLBOX_TARGET_DIR/composer
 COPY entrypoint.sh /entrypoint.sh
 
-RUN php $TOOLBOX_TARGET_DIR/toolbox install \
+RUN --mount=type=secret,id=composer.auth,target=${COMPOSER_HOME}/auth.json \
+ php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf $COMPOSER_HOME/cache
 
 WORKDIR $TOOLBOX_TARGET_DIR

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -48,6 +48,7 @@ COPY --from=composer:2 /usr/bin/composer $TOOLBOX_TARGET_DIR/composer
 COPY entrypoint.sh /entrypoint.sh
 
 RUN --mount=type=secret,id=composer.auth,target=${COMPOSER_HOME}/auth.json \
+ --mount=type=secret,id=phive.auth,target=${TOOLBOX_TARGET_DIR}/.phive/auth.xml \
  php $TOOLBOX_TARGET_DIR/toolbox install \
  && rm -rf $COMPOSER_HOME/cache
 


### PR DESCRIPTION
This adds a build secret in the Dockerfile that can be provided and will mount over the `.composer/auth.json` in the container while the `toolbox install` command is running.

This will hopefully mean composer is always authenticated and won't be rate-limited. Suggestions about how to tell from composer's output whether it's authed would be welcome.

I'm not sure how to do the same for Phive. They only support a token as environment variable, which would leave the secret in the image (see https://github.com/phar-io/phive/issues/372).