### PR TITLE
feat: hide output of automatic call to `composer install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,7 +206,7 @@ COPY --link --chmod=755 <<EOF /entrypoint.sh
 #!/usr/bin/env sh
 set -e
 
-(test "\$GITHUB_ACTIONS" = "true" || test "\$CI" = "true") && test -f composer.json && composer install --no-scripts --no-progress
+(test "\$GITHUB_ACTIONS" = "true" || test "\$CI" = "true") && test -f composer.json && composer install --no-scripts --no-progress --quiet
 
 exec "\$@"
 EOF


### PR DESCRIPTION
We used `jakzal/phpqa` on GitHub Actions:

https://github.com/liip/LiipTestFixturesBundle/blob/16da6812375dc84e537f1ba73cb88a7108ba256e/.github/workflows/qa.yml?plain=1#L29-L36

`composer install` was called automatically because of this line:

https://github.com/jakzal/phpqa/blob/7c5e94df1e3bbb97c8c26b4e08066f1b1b54b742/Dockerfile#L209

It added 270 lines to the job log because `composer install` show every downloaded then installed package.

I had to play with the env vars to hide the output of Composer while keeping the output of PHPStan:

- https://github.com/liip/LiipTestFixturesBundle/pull/360/files (changes)
- https://github.com/liip/LiipTestFixturesBundle/pull/360 (PR)

With this PR, the output of `composer install` will be disabled, so that we will only see the output of the tool.

If there is an error, `composer` will display it, so it should not cause unexpected issues by hiding important information.