### PR TITLE
feat: add option to skip `composer install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,7 +206,7 @@ COPY --link --chmod=755 <<EOF /entrypoint.sh
 #!/usr/bin/env sh
 set -e
 
-(test "\$GITHUB_ACTIONS" = "true" || test "\$CI" = "true") && test -f composer.json && composer install --no-scripts --no-progress --quiet
+(test "\$GITHUB_ACTIONS" = "true" || test "\$CI" = "true") && (test "\$SKIP_COMPOSER_INSTALL" != "true") && test -f composer.json && composer install --no-scripts --no-progress --quiet
 
 exec "\$@"
 EOF

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -12,3 +12,4 @@ Here you will find a list of tips & tricks that are too long to be put in the ma
 - [Bitbucket Pipelines](bitbucket-pipelines.md)
 - [Gitlab CI](gitlab-ci.md)
 - [Starter Kits](starter-kits.md)
+- [Options](options.md)

--- a/docs/cookbook/github-actions.md
+++ b/docs/cookbook/github-actions.md
@@ -24,6 +24,9 @@ jobs:
         uses: docker://jakzal/phpqa:php8.2-alpine
         with:
           args: php-cs-fixer --dry-run --allow-risky=yes --no-interaction --ansi fix
+        env:
+          # set to “true” if the tool can work without Composer dependencies
+          SKIP_COMPOSER_INSTALL: false
       - name: Deptrac
         uses: docker://jakzal/phpqa:php8.2-alpine
         with:

--- a/docs/cookbook/gitlab-ci.md
+++ b/docs/cookbook/gitlab-ci.md
@@ -14,6 +14,9 @@ stages:
 php-cs-fixer:
     stage: style
     image: jakzal/phpqa:php8.2-alpine
+    variables:
+      # set to “true” if the tool can work without Composer dependencies
+      SKIP_COMPOSER_INSTALL: false
     script:
         - php-cs-fixer fix --dry-run --stop-on-violation
 
@@ -23,4 +26,3 @@ phpstan:
     script:
       - phpstan analyze
 ```
-

--- a/docs/cookbook/options.md
+++ b/docs/cookbook/options.md
@@ -1,0 +1,9 @@
+# Options
+
+*Contributed by [alexislefebvre](https://github.com/alexislefebvre).*
+
+For tools that don’t require Composer dependencies, e.g. `php-cs-fixer`,
+you can skip the automatic `composer install` <sup>(1)</sup>
+by defining the value `SKIP_COMPOSER_INSTALL` to `true` (it’s a string).
+
+<sup>(1)</sup> it’s configured in the [`Dockerfile`](https://github.com/jakzal/phpqa/blob/master/Dockerfile).


### PR DESCRIPTION
I’m currently testing [Gitea Actions](https://docs.gitea.com/next/usage/actions/overview) and the fastest way I found to run `php-cs-fixer` is to run it without dependencies. (the syntax of Gitea Actions is based on GitHub Actions so it may look familiar)

```yaml
    php-cs-fixer:
        name: 🧹 PHP-CS-Fixer
        runs-on: ubuntu-latest

        steps:
            -   name: Checkout
                uses: https://github.com/actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

            -   name: ✅ PHP-CS-Fixer
                uses: docker://jakzal/phpqa:1.116.0-php8.4-alpine
                with:
                    args: php-cs-fixer --config=./.qa/.php-cs-fixer.dist.php --dry-run --diff --no-interaction --ansi --show-progress=none fix
                env:
                    CI: false
```

I rely on this line to skip `composer install`: https://github.com/jakzal/phpqa/blob/e144e1cce861283e6db916ffd9f41ce6024cd05a/Dockerfile#L209

But I don’t like having to write `GITHUB_ACTIONS` since it’s a Gitea Actions (it may also be a GitLab CI job), and writing `CI` looks weird since this is still a CI job.

So I propose to add an env var to skip it with an explicit name.

---

### Proof that `php-cs-fixer` works without dependencies

```bash
$ git clone git@github.com:liip/LiipTestFixturesBundle.git
$ cd LiipTestFixturesBundle/
$ docker run --rm -it --volume .:/app --workdir /app jakzal/phpqa:1.116.2-php8.4-alpine php-cs-fixer \
--config=./.qa/.php-cs-fixer.dist.php --dry-run --diff --no-interaction --ansi --show-progress=none fix
…

PHP CS Fixer 3.92.0 (7b15cb5) Exceptional Exception by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.4.15
Loaded config default from "./.qa/.php-cs-fixer.dist.php".
Running analysis on 1 core sequentially.
You can enable parallel runner and speed up the analysis! Please see usage docs for more information.
Using cache file ".php-cs-fixer.cache".

Found 0 of 64 files that can be fixed in 0.002 seconds, 11.34 MB memory used
```